### PR TITLE
Improve CI/CD pipelines with gitflow and conventions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -125,7 +125,7 @@ jobs:
       run: dotnet build --no-restore --configuration Release
 
     - name: Test
-      run: dotnet test --no-build --verbosity normal --configuration Release
+      run: dotnet test --no-build --verbosity ${{ inputs.logLevel || 'minimal' }} --configuration Release
 
     - name: Set version in csproj
       run: |
@@ -173,7 +173,7 @@ jobs:
     - name: Run smoke tests
       run: >
         dotnet test IO.Astrodynamics.SmokeTests/IO.Astrodynamics.SmokeTests.csproj
-        --no-restore --verbosity normal --configuration Release
+        --no-restore --verbosity ${{ inputs.logLevel || 'minimal' }} --configuration Release
 
   # Job 4: Publish to NuGet (only after smoke tests pass on both platforms)
   publish:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,25 +3,44 @@ name: Astrodynamics CD
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
           logLevel:
             description: 'Log level'
             required: true
-            default: 'warning'
+            default: 'minimal'
             type: choice
             options:
-            - info
-            - warning
-            - debug
+            - minimal
+            - normal
+            - detailed
+            - diagnostic
 
 env:
   BUILD_TYPE: Release
 
 jobs:
+  # Job 0: Extract version from tag
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+    - name: Extract version
+      id: extract
+      run: |
+        REF="${{ github.ref_name }}"
+        if [[ "$REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          VERSION="$REF"
+        else
+          VERSION="0.0.0-dev"
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   # Job 1: Build and test C++ native library on both platforms
   build-native:
+    needs: get-version
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -67,7 +86,7 @@ jobs:
 
   # Job 2: Build, test, and pack the NuGet package
   package-dotnet:
-    needs: build-native
+    needs: [get-version, build-native]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -107,6 +126,11 @@ jobs:
 
     - name: Test
       run: dotnet test --no-build --verbosity normal --configuration Release
+
+    - name: Set version in csproj
+      run: |
+        sed -i 's|<Version>.*</Version>|<Version>${{ needs.get-version.outputs.version }}</Version>|' \
+          IO.Astrodynamics/IO.Astrodynamics.csproj
 
     - name: Package Framework
       run: dotnet pack IO.Astrodynamics/IO.Astrodynamics.csproj --no-build --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,21 @@ name: Astrodynamics CI
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
+  push:
+    branches: [ "develop", "release/*", "hotfix/*" ]
   workflow_dispatch:
     inputs:
           logLevel:
             description: 'Log level'
             required: true
-            default: 'warning'
+            default: 'minimal'
             type: choice
             options:
-            - info
-            - warning
-            - debug
+            - minimal
+            - normal
+            - detailed
+            - diagnostic
 
 env:
   BUILD_TYPE: Release
@@ -101,4 +104,4 @@ jobs:
       run: dotnet restore
 
     - name: Test
-      run: dotnet test --verbosity Normal -c Release
+      run: dotnet test --verbosity ${{ inputs.logLevel || 'minimal' }} -c Release


### PR DESCRIPTION
## Summary
- Add `develop` branch to CI pull_request triggers
- Add CI push triggers on `develop`, `release/*`, `hotfix/*`
- Add logLevel options (minimal/normal/detailed/diagnostic, default: minimal)
- Dynamic verbosity in all `dotnet test` steps (`${{ inputs.logLevel || 'minimal' }}`)
- Switch CD tag format from `v*` to semver without prefix (`1.0.0`)
- Add `get-version` job that extracts version from Git tag and injects it into `.csproj` before pack

## Impact
The NuGet package version is now driven by the Git tag — no more risk of tag/package version mismatch.