### PR TITLE
Fix/cli

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -118,6 +118,13 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
+    - name: Set version in csproj
+      run: |
+        sed -i 's|<Version>.*</Version>|<Version>${{ needs.get-version.outputs.version }}</Version>|' \
+          IO.Astrodynamics/IO.Astrodynamics.csproj
+        sed -i 's|<Version>.*</Version>|<Version>${{ needs.get-version.outputs.version }}</Version>|' \
+          IO.Astrodynamics.CLI/IO.Astrodynamics.CLI.csproj
+
     - name: Restore dependencies
       run: dotnet restore
 
@@ -127,19 +134,24 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity ${{ inputs.logLevel || 'minimal' }} --configuration Release
 
-    - name: Set version in csproj
-      run: |
-        sed -i 's|<Version>.*</Version>|<Version>${{ needs.get-version.outputs.version }}</Version>|' \
-          IO.Astrodynamics/IO.Astrodynamics.csproj
-
     - name: Package Framework
       run: dotnet pack IO.Astrodynamics/IO.Astrodynamics.csproj --no-build --configuration Release
+
+    - name: Package CLI
+      run: dotnet pack IO.Astrodynamics.CLI/IO.Astrodynamics.CLI.csproj --no-build --configuration Release
+
+    - name: Stage NuGet packages
+      run: |
+        mkdir -p nupkg-staging
+        cp IO.Astrodynamics/bin/Release/*.nupkg nupkg-staging/
+        cp IO.Astrodynamics.CLI/bin/Release/*.nupkg nupkg-staging/
+        ls -la nupkg-staging/
 
     - name: Upload NuGet package
       uses: actions/upload-artifact@v4
       with:
         name: nuget-package
-        path: IO.Astrodynamics.Net/IO.Astrodynamics/bin/Release/*.nupkg
+        path: IO.Astrodynamics.Net/nupkg-staging/*.nupkg
         retention-days: 5
 
   # Job 3: Smoke-test the NuGet package on both platforms

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/BodyInformationTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/BodyInformationTests.cs
@@ -8,7 +8,7 @@ public class BodyInformationsTests
     [Fact]
     public void CelestialBodyInformation()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new BodyInformationCommand();
             StringBuilder sb = new StringBuilder();

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/Configuration.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/Configuration.cs
@@ -1,8 +1,37 @@
 // Copyright 2024. Sylvain Guillet (sylvain.guillet@tutamail.com)
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace IO.Astrodynamics.CLI.Tests;
 
-public class Configuration
+public static class Configuration
 {
-    public static object objLock = new Object();
+    private static readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+
+    public static IDisposable Lock()
+    {
+        _lock.Wait();
+        return new Releaser();
+    }
+
+    public static async Task<IDisposable> LockAsync()
+    {
+        await _lock.WaitAsync();
+        return new Releaser();
+    }
+
+    private sealed class Releaser : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                _lock.Release();
+            }
+        }
+    }
 }

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/EphemerisTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/EphemerisTests.cs
@@ -11,7 +11,7 @@ public class EphemerisTests
     [Fact]
     public void CallWithAllOptions()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new EphemerisCommand();
             StringBuilder sb = new StringBuilder();
@@ -34,7 +34,7 @@ public class EphemerisTests
     [Fact]
     public void CallWithoutOptions()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new EphemerisCommand();
             StringBuilder sb = new StringBuilder();
@@ -58,7 +58,7 @@ public class EphemerisTests
     [Fact]
     public void SubPoint()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new EphemerisCommand();
             StringBuilder sb = new StringBuilder();
@@ -75,7 +75,7 @@ public class EphemerisTests
     [Fact]
     public void SubPointCartesian()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new EphemerisCommand();
             StringBuilder sb = new StringBuilder();
@@ -92,7 +92,7 @@ public class EphemerisTests
     [Fact]
     public void SubPointPlanetodetic()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new EphemerisCommand();
             StringBuilder sb = new StringBuilder();
@@ -109,7 +109,7 @@ public class EphemerisTests
     [Fact]
     public void AngularSeparation()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new EphemerisCommand();
             StringBuilder sb = new StringBuilder();

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/FrameTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/FrameTests.cs
@@ -9,7 +9,7 @@ public class FrameTests
     [Fact]
     public void Convert()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new FrameConverterCommand();
             StringBuilder sb = new StringBuilder();

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/GeometryFinderTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/GeometryFinderTests.cs
@@ -9,7 +9,7 @@ public class GeometryFinderTests
     [Fact]
     public void CoordinateConstraint()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new GeometryFinderCommand();
             StringBuilder sb = new StringBuilder();
@@ -29,7 +29,7 @@ public class GeometryFinderTests
     [Fact]
     public void DistanceConstraint()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new GeometryFinderCommand();
             StringBuilder sb = new StringBuilder();
@@ -49,7 +49,7 @@ public class GeometryFinderTests
     [Fact]
     public void OccultationConstraint()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new GeometryFinderCommand();
             StringBuilder sb = new StringBuilder();
@@ -69,7 +69,7 @@ public class GeometryFinderTests
     [Fact]
     public void FOVConstraint()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new GeometryFinderCommand();
             StringBuilder sb = new StringBuilder();
@@ -89,7 +89,7 @@ public class GeometryFinderTests
     public void IlluminationConstraint()
     {
         //Find time windows when the planetodetic point is illuminated by the sun (Official twilight 0.8° bellow horizon)
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new GeometryFinderCommand();
             StringBuilder sb = new StringBuilder();

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/OrbitalParametersTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/OrbitalParametersTests.cs
@@ -9,7 +9,7 @@ public class OrbitalParametersTests
     [Fact]
     public void SvToSv()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrbitalParametersConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -33,7 +33,7 @@ public class OrbitalParametersTests
     [Fact]
     public void SvToSvToDifferentFrame()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrbitalParametersConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -57,7 +57,7 @@ public class OrbitalParametersTests
     [Fact]
     public void SvToKeplerian()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrbitalParametersConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -82,7 +82,7 @@ public class OrbitalParametersTests
     [Fact]
     public void KeplerianToEquinocial()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrbitalParametersConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -114,7 +114,7 @@ public class OrbitalParametersTests
     [Fact]
     public void KeplerianToSv()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrbitalParametersConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -146,7 +146,7 @@ public class OrbitalParametersTests
     [Fact]
     public void KeplerianToKeplerian()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrbitalParametersConverterCommand();
             StringBuilder sb = new StringBuilder();

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/OrientationTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/OrientationTests.cs
@@ -11,7 +11,7 @@ public class OrientationsTests
     [Fact]
     public void CallWithAllOptions()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrientationCommand();
             StringBuilder sb = new StringBuilder();
@@ -34,7 +34,7 @@ public class OrientationsTests
     [Fact]
     public void CallWithoutOptions()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new OrientationCommand();
             StringBuilder sb = new StringBuilder();

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/PropagateTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/PropagateTests.cs
@@ -9,28 +9,28 @@ namespace IO.Astrodynamics.CLI.Tests;
 public class PropagateTests
 {
     [Fact]
-    public void PropagateWithPerturbations()
+    public async Task PropagateWithPerturbations()
     {
         var command = new PropagateCommand();
         StringBuilder sb = new StringBuilder();
         StringWriter sw = new StringWriter(sb);
         string res;
 
-        lock (Configuration.objLock)
+        using (await Configuration.LockAsync())
         {
             Console.SetOut(sw);
 
-            command.Propagate("Data", "MyBody",
+            await command.Propagate("Data", "MyBody",
                 new Commands.Parameters.OrbitalParameters
                 {
                     CenterOfMotionId = 399, OrbitalParametersEpoch = "0.0", Frame = "ICRF", OrbitalParametersValues = "6800000.0 0.0 0.0 0.0 8000.0 0.0",
                     FromStateVector = true
                 }, new WindowParameters { Begin = "0.0", End = "3600.0" }, "PropagatorExport", true,
-                true, 20, celestialBodies: [10, 301]).Wait();
+                true, 20, celestialBodies: [10, 301]);
 
             res = sb.ToString();
         }
-        
+
         Assert.Contains("Propagation completed", res);
     }
 }

--- a/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/TimeTests.cs
+++ b/IO.Astrodynamics.Net/IO.Astrodynamics.CLI.Tests/TimeTests.cs
@@ -10,7 +10,7 @@ public class TimeTests
     [Fact]
     public void DateToJDUTC()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -26,7 +26,7 @@ public class TimeTests
     [Fact]
     public void DateToSecondsFromJ2000()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -42,7 +42,7 @@ public class TimeTests
     [Fact]
     public void DateToDateTDB()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -58,7 +58,7 @@ public class TimeTests
     [Fact]
     public void J2000ToDateUTC()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -74,7 +74,7 @@ public class TimeTests
     // [Fact]
     internal void J2000ToLocal()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -90,7 +90,7 @@ public class TimeTests
     [Fact]
     public void LocalToJ2000()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -106,7 +106,7 @@ public class TimeTests
     [Fact]
     public void J2000ToJulianTDB()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -122,7 +122,7 @@ public class TimeTests
     [Fact]
     public void J2000ToJ2000UTC()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -138,7 +138,7 @@ public class TimeTests
     [Fact]
     public void JulianToJ2000TDB()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -154,7 +154,7 @@ public class TimeTests
     [Fact]
     public void JulianToDateTDB()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -170,7 +170,7 @@ public class TimeTests
     [Fact]
     public void JulianToJulianUTC()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();
@@ -186,7 +186,7 @@ public class TimeTests
     [Fact]
     public async Task Exceptions()
     {
-        lock (Configuration.objLock)
+        using (Configuration.Lock())
         {
             var command = new TimeConverterCommand();
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
This pull request refactors the test synchronization mechanism in the CLI test suite and improves the packaging process in the CI/CD workflow. The most important changes are the introduction of a safer, disposable-based locking mechanism for test synchronization, updates to all test files to use this mechanism, and enhancements to the GitHub Actions workflow for packaging and publishing NuGet packages.

### Test synchronization improvements

* Replaced the static `objLock` object in `Configuration.cs` with a static `SemaphoreSlim`-based locking mechanism, providing both synchronous (`Lock()`) and asynchronous (`LockAsync()`) disposable lock acquisition methods for safer and more flexible test synchronization.
* Updated all test files (e.g., `BodyInformationTests.cs`, `EphemerisTests.cs`, `FrameTests.cs`, `GeometryFinderTests.cs`, `OrbitalParametersTests.cs`, `OrientationTests.cs`, `PropagateTests.cs`, `TimeTests.cs`) to use the new `using (Configuration.Lock())` or `using (await Configuration.LockAsync())` pattern instead of `lock (Configuration.objLock)`. This ensures proper lock release and supports async tests. [[1]](diffhunk://#diff-38c59ab9fbd1b196ed58d00ec68305611073b859f090e4076fbb8c96cbbd02d5L11-R11) [[2]](diffhunk://#diff-26b7e80020a1162b187653a7337c6e5297a9d069f1303b165c6d1bc46787dfd2L14-R14) [[3]](diffhunk://#diff-85f479f5e9bb62f8d62004c745f3d14e86a2b6ff6aac2aead5dfaafc8012c490L12-R12) [[4]](diffhunk://#diff-bf2b33f47d211b562539ebc09d08f22b0b3f4765b3e19135fb6aadf8984a08e3L12-R12) [[5]](diffhunk://#diff-48d8abf7063cc982edd2c1f37bb386a20341c157cd91886078d8f5579d0e07c9L12-R12) [[6]](diffhunk://#diff-901a9308b9cb051b20cf5f91e59a462387e9b28047f8638b3d6ee145d7a2fae9L14-R14) [[7]](diffhunk://#diff-3bebe1a46ed173c8366ee15e87a1cd7654420eab243e1b685ddb9d637a64345dL12-R29) [[8]](diffhunk://#diff-036e307c3b3164bce9fc8d7a43322acad4047ec054ec9b93ffb6a6be27bac56aL13-R13) etc.)

### CI/CD and packaging workflow enhancements

* Moved the version-setting step for `.csproj` files earlier in the workflow to ensure the correct version is set before restoring dependencies.
* Added packaging for the CLI project (`dotnet pack IO.Astrodynamics.CLI/IO.Astrodynamics.CLI.csproj`) and a staging step that collects all NuGet packages into a `nupkg-staging` directory.
* Updated the artifact upload step to upload all staged NuGet packages, ensuring both framework and CLI packages are available as build artifacts.

These changes improve test reliability, make the test suite safer for parallel execution, and streamline the packaging and publishing process in CI/CD.
 